### PR TITLE
🐛 Support AGP 8.1.0 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
 repositories {
   jcenter()
   google()
+  mavenCentral()
 }
 
 java {
@@ -24,12 +25,12 @@ dependencies {
   testImplementation(group: 'org.spockframework', name: 'spock-core', version: '1.1-groovy-2.4') {
     exclude group: 'org.codehaus.groovy', module: 'groovy-all'
   }
-  testImplementation 'com.android.tools.build:gradle:3.5.2'
-  testImplementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50'
+  testImplementation 'com.android.tools.build:gradle:8.1.0'
+  testImplementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
 }
 
 group = 'com.hiya'
-version = "0.2"
+version = "0.3"
 
 gradlePlugin {
   plugins {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/hiya/plugins/JacocoAndroidPlugin.groovy
+++ b/src/main/groovy/com/hiya/plugins/JacocoAndroidPlugin.groovy
@@ -85,19 +85,19 @@ class JacocoAndroidPlugin implements Plugin<ProjectInternal> {
     reportTask.reports {
       def destination = project.jacocoAndroidUnitTestReport.destination
       
-      csv.enabled project.jacocoAndroidUnitTestReport.csv.enabled
-      html.enabled project.jacocoAndroidUnitTestReport.html.enabled
-      xml.enabled project.jacocoAndroidUnitTestReport.xml.enabled
+      csv.required.set(project.jacocoAndroidUnitTestReport.csv.enabled)
+      html.required.set(project.jacocoAndroidUnitTestReport.html.enabled)
+      xml.required.set(project.jacocoAndroidUnitTestReport.xml.enabled)
 
-      if (csv.enabled) {
+      if (csv.required.get()) {
         csv.destination new File((destination == null) ? "${project.buildDir}/jacoco/jacoco.csv" : "${destination.trim()}/jacoco.csv")
       }
       
-      if (html.enabled) {
+      if (html.required.get()) {
         html.destination new File((destination == null) ? "${project.buildDir}/jacoco/jacocoHtml" : "${destination.trim()}/jacocoHtml")
       }
 
-      if (xml.enabled) {
+      if (xml.required.get()) {
         xml.destination new File((destination == null) ? "${project.buildDir}/jacoco/jacoco.xml" : "${destination.trim()}/jacoco.xml")
       }
     }
@@ -132,9 +132,9 @@ class JacocoAndroidPlugin implements Plugin<ProjectInternal> {
     logger.info("Added $reportTask")
     logger.info("  executionData: $reportTask.executionData.asPath")
     logger.info("  sourceDirectories: $reportTask.sourceDirectories.asPath")
-    logger.info("  csv.destination: $reportTask.reports.csv.destination")
-    logger.info("  xml.destination: $reportTask.reports.xml.destination")
-    logger.info("  html.destination: $reportTask.reports.html.destination")
+    logger.info("  csv.destination: $reportTask.reports.csv.outputLocation")
+    logger.info("  xml.destination: $reportTask.reports.xml.outputLocation")
+    logger.info("  html.destination: $reportTask.reports.html.outputLocation")
 
   }
 }


### PR DESCRIPTION
**Changes**

- Replace `enabled` calls with `required`
- Replace `destination` calls with `outputLocation`
- Change AGP and Kotlin versions (Not sure if this is needed)